### PR TITLE
fix(keyboard): prevent system freeze when accessibility permission is revoked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,8 @@ dependencies = [
 name = "dictara-keyboard"
 version = "0.1.0"
 dependencies = [
+ "log",
+ "macos-accessibility-client",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "thiserror 2.0.17",

--- a/crates/keyboard/Cargo.toml
+++ b/crates/keyboard/Cargo.toml
@@ -7,7 +7,9 @@ description = "Cross-platform keyboard event grabbing with rdev-like API"
 
 [dependencies]
 thiserror = "2"
+log = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-core-graphics = "0.3.1"
 objc2-core-foundation = "0.3.1"
+macos-accessibility-client = "0.0.1"

--- a/crates/keyboard/src/lib.rs
+++ b/crates/keyboard/src/lib.rs
@@ -37,6 +37,10 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum GrabError {
+    /// Accessibility permission is not granted (macOS).
+    #[error("Accessibility permission not granted")]
+    AccessibilityNotGranted,
+
     /// Failed to create event tap (macOS). Usually means accessibility permission is missing.
     #[error("Failed to create event tap (check accessibility permissions)")]
     EventTapError,


### PR DESCRIPTION
## Summary

- Added polling thread that checks accessibility permission every 200ms
- Handle `TapDisabledByTimeout` and `TapDisabledByUserInput` events properly
- Graceful stop of CFRunLoop when permission is lost
- Added `macos-accessibility-client` dependency for permission checking
- Added logging for debugging

## Problem

When accessibility permission was revoked while the keyboard event tap was active, macOS would freeze the system for ~30 seconds before sending `TapDisabledByTimeout`.

## Solution

A polling thread now checks `AXIsProcessTrusted()` every 200ms. If permission is lost, it immediately stops the CFRunLoop, preventing the freeze.

## Test plan

- [x] Run the app with accessibility permission enabled
- [x] Revoke accessibility permission while the app is running
- [x] Verify system does not freeze and app logs show "Accessibility permission lost (detected by polling), stopping event tap"