### PR TITLE
feat: add OpenAI transcription model selection

### DIFF
--- a/src-tauri/src/clients/config.rs
+++ b/src-tauri/src/clients/config.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use secrecy::SecretString;
 
-use crate::config::Provider;
+use crate::config::{OpenAITranscriptionModel, Provider};
 
 /// Configuration for making transcription API calls
 pub struct ApiConfig {
@@ -10,6 +10,8 @@ pub struct ApiConfig {
     pub api_key: SecretString,
     /// Full transcription endpoint for Azure (without api-version), unused for OpenAI
     pub endpoint: String,
+    /// Transcription model to use, only meaningful for the OpenAI provider
+    pub openai_model: OpenAITranscriptionModel,
 }
 
 impl fmt::Debug for ApiConfig {
@@ -18,6 +20,7 @@ impl fmt::Debug for ApiConfig {
             .field("provider", &self.provider)
             .field("api_key", &"[REDACTED]")
             .field("endpoint", &self.endpoint)
+            .field("openai_model", &self.openai_model)
             .finish()
     }
 }

--- a/src-tauri/src/clients/openai_client.rs
+++ b/src-tauri/src/clients/openai_client.rs
@@ -4,18 +4,19 @@ use secrecy::{ExposeSecret, SecretString};
 
 use super::client::TranscriptionClient;
 use super::error::TranscriptionError;
+use crate::config::OpenAITranscriptionModel;
 
 const OPENAI_TRANSCRIPTION_URL: &str = "https://api.openai.com/v1/audio/transcriptions";
-const OPENAI_MODEL: &str = "whisper-1";
 
-/// OpenAI Whisper API client
+/// OpenAI file-transcription API client
 pub struct OpenAIClient {
     api_key: SecretString,
+    model: OpenAITranscriptionModel,
 }
 
 impl OpenAIClient {
-    pub fn new(api_key: SecretString) -> Self {
-        Self { api_key }
+    pub fn new(api_key: SecretString, model: OpenAITranscriptionModel) -> Self {
+        Self { api_key, model }
     }
 }
 
@@ -35,7 +36,7 @@ impl TranscriptionClient for OpenAIClient {
         &self,
         file_path: &Path,
     ) -> Result<reqwest::blocking::multipart::Form, TranscriptionError> {
-        let form = reqwest::blocking::multipart::Form::new()
+        let mut form = reqwest::blocking::multipart::Form::new()
             .file("file", file_path)
             .map_err(|e| {
                 TranscriptionError::IoError(std::io::Error::other(format!(
@@ -43,10 +44,70 @@ impl TranscriptionClient for OpenAIClient {
                     e
                 )))
             })?
-            .text("model", OPENAI_MODEL)
-            .text("temperature", "0.0")
-            .text("response_format", "json");
+            .text("model", self.model.as_api_id())
+            .text("response_format", self.model.response_format());
+
+        // Only whisper-1 documents a sampling temperature; sending it to the
+        // GPT-based transcription models is rejected as an unknown parameter.
+        if self.model.supports_temperature() {
+            form = form.text("temperature", "0.0");
+        }
+
+        // gpt-4o-transcribe-diarize requires a chunking strategy for audio
+        // longer than 30 seconds.
+        if self.model.requires_chunking_strategy() {
+            form = form.text("chunking_strategy", "auto");
+        }
 
         Ok(form)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client(model: OpenAITranscriptionModel) -> OpenAIClient {
+        OpenAIClient::new(SecretString::from("sk-test".to_string()), model)
+    }
+
+    #[test]
+    fn uses_the_selected_model_endpoint() {
+        assert_eq!(
+            client(OpenAITranscriptionModel::GptTranscribe).transcription_url(),
+            OPENAI_TRANSCRIPTION_URL
+        );
+    }
+
+    #[test]
+    fn builds_a_form_for_every_supported_model() {
+        let mut file = std::env::temp_dir();
+        file.push("dictara_openai_client_form_test.wav");
+        std::fs::write(&file, b"RIFF").expect("write temp audio");
+
+        for model in [
+            OpenAITranscriptionModel::GptTranscribe,
+            OpenAITranscriptionModel::Gpt4oTranscribe,
+            OpenAITranscriptionModel::Gpt4oMiniTranscribe,
+            OpenAITranscriptionModel::Gpt4oTranscribeDiarize,
+            OpenAITranscriptionModel::Whisper1,
+        ] {
+            assert!(
+                client(model).build_form_from_path(&file).is_ok(),
+                "form must build for {}",
+                model.as_api_id()
+            );
+        }
+
+        let _ = std::fs::remove_file(&file);
+    }
+
+    #[test]
+    fn missing_file_is_an_io_error() {
+        let missing = std::env::temp_dir().join("dictara_openai_client_missing.wav");
+        let _ = std::fs::remove_file(&missing);
+
+        let result = client(OpenAITranscriptionModel::Whisper1).build_form_from_path(&missing);
+        assert!(matches!(result, Err(TranscriptionError::IoError(_))));
     }
 }

--- a/src-tauri/src/clients/transcriber.rs
+++ b/src-tauri/src/clients/transcriber.rs
@@ -6,7 +6,8 @@ use secrecy::{ExposeSecret, SecretString};
 use tauri::{AppHandle, Manager};
 
 use crate::config::{
-    self, AzureOpenAIConfig, ConfigKey, ConfigStore, LocalModelConfig, OpenAIConfig, Provider,
+    self, AzureOpenAIConfig, ConfigKey, ConfigStore, LocalModelConfig, OpenAIConfig,
+    OpenAITranscriptionModel, Provider,
 };
 use crate::keychain::{self, ProviderAccount};
 use crate::models::{is_model_in_catalog, ModelLoader, ModelManager};
@@ -152,9 +153,10 @@ impl Transcriber {
                 let config: OpenAIConfig = keychain::load_provider_config(ProviderAccount::OpenAI)
                     .map_err(|_| TranscriptionError::ApiKeyMissing)?
                     .ok_or(TranscriptionError::ApiKeyMissing)?;
-                Ok(Box::new(OpenAIClient::new(SecretString::from(
-                    config.api_key,
-                ))))
+                Ok(Box::new(OpenAIClient::new(
+                    SecretString::from(config.api_key),
+                    config.model,
+                )))
             }
             Provider::AzureOpenAI => {
                 let config: AzureOpenAIConfig =
@@ -207,9 +209,10 @@ impl Transcriber {
     /// Create client from explicit config (for testing credentials).
     fn create_client_from_explicit_config(config: &ApiConfig) -> Box<dyn TranscriptionClient> {
         match config.provider {
-            Provider::OpenAI => Box::new(OpenAIClient::new(SecretString::from(
-                config.api_key.expose_secret().to_owned(),
-            ))),
+            Provider::OpenAI => Box::new(OpenAIClient::new(
+                SecretString::from(config.api_key.expose_secret().to_owned()),
+                config.openai_model,
+            )),
             Provider::AzureOpenAI => Box::new(AzureClient::new(
                 SecretString::from(config.api_key.expose_secret().to_owned()),
                 config.endpoint.clone(),
@@ -217,7 +220,10 @@ impl Transcriber {
             Provider::Local => {
                 // Local provider doesn't use API testing - just return OpenAI client
                 // This code path shouldn't be reached for Local provider
-                Box::new(OpenAIClient::new(SecretString::from(String::new())))
+                Box::new(OpenAIClient::new(
+                    SecretString::from(String::new()),
+                    OpenAITranscriptionModel::default(),
+                ))
             }
         }
     }

--- a/src-tauri/src/commands/preferences/api_keys/provider_azure_openai.rs
+++ b/src-tauri/src/commands/preferences/api_keys/provider_azure_openai.rs
@@ -61,6 +61,7 @@ pub fn test_azure_openai_config(api_key: String, endpoint: String) -> Result<boo
         provider: Provider::AzureOpenAI,
         api_key: SecretString::from(api_key),
         endpoint,
+        openai_model: crate::config::OpenAITranscriptionModel::default(),
     };
 
     Transcriber::test_api_key(&config).map_err(|e| {

--- a/src-tauri/src/commands/preferences/api_keys/provider_openai.rs
+++ b/src-tauri/src/commands/preferences/api_keys/provider_openai.rs
@@ -2,7 +2,7 @@ use secrecy::SecretString;
 use serde::Serialize;
 
 use crate::clients::{ApiConfig, Transcriber};
-use crate::config::{OpenAIConfig, Provider};
+use crate::config::{OpenAIConfig, OpenAITranscriptionModel, Provider};
 use crate::keychain::{self, ProviderAccount};
 use log::error;
 
@@ -11,6 +11,8 @@ use log::error;
 #[serde(rename_all = "camelCase")]
 pub struct OpenAIConfigStatus {
     pub configured: bool,
+    /// Currently selected transcription model (never includes the API key)
+    pub model: OpenAITranscriptionModel,
 }
 
 // ===== OPENAI PROVIDER COMMANDS =====
@@ -25,13 +27,44 @@ pub fn load_openai_config() -> Result<Option<OpenAIConfigStatus>, String> {
             err
         })?;
 
-    Ok(config.map(|_| OpenAIConfigStatus { configured: true }))
+    Ok(config.map(|c| OpenAIConfigStatus {
+        configured: true,
+        model: c.model,
+    }))
 }
 
+/// Save the OpenAI configuration.
+///
+/// `api_key` is optional: when omitted, the already-stored key is kept so the
+/// model can be changed without the user re-entering their key. The stored key
+/// is never returned to the frontend.
 #[tauri::command]
 #[specta::specta]
-pub fn save_openai_config(api_key: String) -> Result<(), String> {
-    let config = OpenAIConfig { api_key };
+pub fn save_openai_config(
+    api_key: Option<String>,
+    model: OpenAITranscriptionModel,
+) -> Result<(), String> {
+    let api_key = match api_key {
+        Some(key) => key,
+        None => {
+            let existing = keychain::load_provider_config::<OpenAIConfig>(ProviderAccount::OpenAI)
+                .map_err(|e| {
+                    let err = format!("Failed to load OpenAI config: {}", e);
+                    error!("{}", err);
+                    err
+                })?;
+
+            existing
+                .ok_or_else(|| {
+                    let err = "No stored OpenAI API key to update".to_string();
+                    error!("{}", err);
+                    err
+                })?
+                .api_key
+        }
+    };
+
+    let config = OpenAIConfig { api_key, model };
 
     keychain::save_provider_config(ProviderAccount::OpenAI, &config).map_err(|e| {
         let err = format!("Failed to save OpenAI config: {}", e);
@@ -50,6 +83,14 @@ pub fn delete_openai_config() -> Result<(), String> {
     })
 }
 
+/// Verify that an API key is accepted by OpenAI.
+///
+/// This checks the credential, not the model: the probe sends a 1-second
+/// silent clip, which the GPT-based transcription models reject outright
+/// (and which gives the diarization model's VAD nothing to chunk). Whisper
+/// accepts it, so it is always used here regardless of the selected model.
+/// Authorization is account-wide, so a key valid for Whisper is valid for
+/// every transcription model.
 #[tauri::command]
 #[specta::specta]
 pub fn test_openai_config(api_key: String) -> Result<bool, String> {
@@ -57,6 +98,7 @@ pub fn test_openai_config(api_key: String) -> Result<bool, String> {
         provider: Provider::OpenAI,
         api_key: SecretString::from(api_key),
         endpoint: String::new(),
+        openai_model: OpenAITranscriptionModel::Whisper1,
     };
 
     Transcriber::test_api_key(&config).map_err(|e| {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -250,17 +250,83 @@ impl ConfigKey<ShortcutsConfig> {
 
 // ===== Keychain-stored Configurations (no keys) =====
 
+/// File-based OpenAI transcription models supported by `/v1/audio/transcriptions`.
+///
+/// Realtime/live transcription models are intentionally not included.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, specta::Type)]
+pub enum OpenAITranscriptionModel {
+    #[serde(rename = "gpt-transcribe")]
+    GptTranscribe,
+    #[serde(rename = "gpt-4o-transcribe")]
+    Gpt4oTranscribe,
+    #[serde(rename = "gpt-4o-mini-transcribe")]
+    Gpt4oMiniTranscribe,
+    #[serde(rename = "gpt-4o-transcribe-diarize")]
+    Gpt4oTranscribeDiarize,
+    /// Default for backwards compatibility with configs saved before the
+    /// model became selectable.
+    #[default]
+    #[serde(rename = "whisper-1")]
+    Whisper1,
+}
+
+impl OpenAITranscriptionModel {
+    /// The model id as accepted by the OpenAI API.
+    pub fn as_api_id(self) -> &'static str {
+        match self {
+            Self::GptTranscribe => "gpt-transcribe",
+            Self::Gpt4oTranscribe => "gpt-4o-transcribe",
+            Self::Gpt4oMiniTranscribe => "gpt-4o-mini-transcribe",
+            Self::Gpt4oTranscribeDiarize => "gpt-4o-transcribe-diarize",
+            Self::Whisper1 => "whisper-1",
+        }
+    }
+
+    /// `response_format` to request for this model.
+    ///
+    /// `gpt-4o-transcribe-diarize` only produces speaker annotations with
+    /// `diarized_json`; every other supported model accepts plain `json`.
+    /// Both response shapes carry a top-level `text` field.
+    pub fn response_format(self) -> &'static str {
+        match self {
+            Self::Gpt4oTranscribeDiarize => "diarized_json",
+            _ => "json",
+        }
+    }
+
+    /// Whether the model accepts the `temperature` parameter.
+    ///
+    /// Only the Whisper model documents sampling temperature; the GPT-based
+    /// transcription models do not, so it must not be sent for them.
+    pub fn supports_temperature(self) -> bool {
+        matches!(self, Self::Whisper1)
+    }
+
+    /// Whether a `chunking_strategy` must be sent.
+    ///
+    /// Required by `gpt-4o-transcribe-diarize` for audio longer than 30
+    /// seconds, and harmless for shorter clips, so it is always sent.
+    pub fn requires_chunking_strategy(self) -> bool {
+        matches!(self, Self::Gpt4oTranscribeDiarize)
+    }
+}
+
 /// OpenAI provider configuration (stored in keychain)
 #[derive(Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct OpenAIConfig {
     pub api_key: String,
+    /// Selected transcription model. Missing in configs written before model
+    /// selection existed, which fall back to `whisper-1`.
+    #[serde(default)]
+    pub model: OpenAITranscriptionModel,
 }
 
 impl std::fmt::Debug for OpenAIConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpenAIConfig")
             .field("api_key", &"[REDACTED]")
+            .field("model", &self.model)
             .finish()
     }
 }
@@ -467,6 +533,105 @@ mod tests {
         for (description, key, config) in test_cases {
             let store = MockConfigStore::new();
             test_config_lifecycle(&store, &key, config, description);
+        }
+    }
+
+    #[test]
+    fn test_openai_config_without_model_falls_back_to_whisper() {
+        // Configs written before model selection existed only contain the key.
+        let legacy = r#"{"apiKey":"sk-legacy"}"#;
+        let config: OpenAIConfig = serde_json::from_str(legacy).expect("legacy config must load");
+
+        assert_eq!(config.api_key, "sk-legacy");
+        assert_eq!(config.model, OpenAITranscriptionModel::Whisper1);
+        assert_eq!(config.model.as_api_id(), "whisper-1");
+    }
+
+    #[test]
+    fn test_openai_config_roundtrip_preserves_model() {
+        let config = OpenAIConfig {
+            api_key: "sk-test".to_string(),
+            model: OpenAITranscriptionModel::Gpt4oMiniTranscribe,
+        };
+
+        let json = serde_json::to_string(&config).expect("serialize");
+        assert!(
+            json.contains(r#""model":"gpt-4o-mini-transcribe""#),
+            "model must serialize as its API id, got {}",
+            json
+        );
+
+        let restored: OpenAIConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            restored.model,
+            OpenAITranscriptionModel::Gpt4oMiniTranscribe
+        );
+        assert_eq!(restored.api_key, "sk-test");
+    }
+
+    #[test]
+    fn test_openai_model_serialization_matches_api_ids() {
+        let all = [
+            (OpenAITranscriptionModel::GptTranscribe, "gpt-transcribe"),
+            (
+                OpenAITranscriptionModel::Gpt4oTranscribe,
+                "gpt-4o-transcribe",
+            ),
+            (
+                OpenAITranscriptionModel::Gpt4oMiniTranscribe,
+                "gpt-4o-mini-transcribe",
+            ),
+            (
+                OpenAITranscriptionModel::Gpt4oTranscribeDiarize,
+                "gpt-4o-transcribe-diarize",
+            ),
+            (OpenAITranscriptionModel::Whisper1, "whisper-1"),
+        ];
+
+        for (model, api_id) in all {
+            assert_eq!(model.as_api_id(), api_id);
+
+            let json = serde_json::to_string(&model).expect("serialize");
+            assert_eq!(json, format!("\"{}\"", api_id));
+
+            let restored: OpenAITranscriptionModel =
+                serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(restored, model, "roundtrip for {}", api_id);
+        }
+    }
+
+    #[test]
+    fn test_openai_model_request_parameters() {
+        // Only whisper-1 documents a sampling temperature.
+        assert!(OpenAITranscriptionModel::Whisper1.supports_temperature());
+        for model in [
+            OpenAITranscriptionModel::GptTranscribe,
+            OpenAITranscriptionModel::Gpt4oTranscribe,
+            OpenAITranscriptionModel::Gpt4oMiniTranscribe,
+            OpenAITranscriptionModel::Gpt4oTranscribeDiarize,
+        ] {
+            assert!(
+                !model.supports_temperature(),
+                "{} must not receive temperature",
+                model.as_api_id()
+            );
+        }
+
+        // Diarization needs diarized_json plus a chunking strategy.
+        assert_eq!(
+            OpenAITranscriptionModel::Gpt4oTranscribeDiarize.response_format(),
+            "diarized_json"
+        );
+        assert!(OpenAITranscriptionModel::Gpt4oTranscribeDiarize.requires_chunking_strategy());
+
+        for model in [
+            OpenAITranscriptionModel::GptTranscribe,
+            OpenAITranscriptionModel::Gpt4oTranscribe,
+            OpenAITranscriptionModel::Gpt4oMiniTranscribe,
+            OpenAITranscriptionModel::Whisper1,
+        ] {
+            assert_eq!(model.response_format(), "json");
+            assert!(!model.requires_chunking_strategy());
         }
     }
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -101,9 +101,16 @@ async loadOpenaiConfig() : Promise<Result<OpenAIConfigStatus | null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async saveOpenaiConfig(apiKey: string) : Promise<Result<null, string>> {
+/**
+ * Save the OpenAI configuration.
+ * 
+ * `api_key` is optional: when omitted, the already-stored key is kept so the
+ * model can be changed without the user re-entering their key. The stored key
+ * is never returned to the frontend.
+ */
+async saveOpenaiConfig(apiKey: string | null, model: OpenAITranscriptionModel) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("save_openai_config", { apiKey }) };
+    return { status: "ok", data: await TAURI_INVOKE("save_openai_config", { apiKey, model }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -117,6 +124,16 @@ async deleteOpenaiConfig() : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Verify that an API key is accepted by OpenAI.
+ * 
+ * This checks the credential, not the model: the probe sends a 1-second
+ * silent clip, which the GPT-based transcription models reject outright
+ * (and which gives the diarization model's VAD nothing to chunk). Whisper
+ * accepts it, so it is always used here regardless of the selected model.
+ * Authorization is account-wide, so a key valid for Whisper is valid for
+ * every transcription model.
+ */
 async testOpenaiConfig(apiKey: string) : Promise<Result<boolean, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("test_openai_config", { apiKey }) };
@@ -574,7 +591,22 @@ export type OnboardingStep = "welcome" | "accessibility" | "microphone" | "api_k
 /**
  * Frontend-facing status for OpenAI provider (never exposes API key)
  */
-export type OpenAIConfigStatus = { configured: boolean }
+export type OpenAIConfigStatus = { configured: boolean; 
+/**
+ * Currently selected transcription model (never includes the API key)
+ */
+model: OpenAITranscriptionModel }
+/**
+ * File-based OpenAI transcription models supported by `/v1/audio/transcriptions`.
+ * 
+ * Realtime/live transcription models are intentionally not included.
+ */
+export type OpenAITranscriptionModel = "gpt-transcribe" | "gpt-4o-transcribe" | "gpt-4o-mini-transcribe" | "gpt-4o-transcribe-diarize" | 
+/**
+ * Default for backwards compatibility with configs saved before the
+ * model became selectable.
+ */
+"whisper-1"
 /**
  * Provider types supported by the application
  */

--- a/src/components/preferences/api-keys/OpenAIModelSelector.tsx
+++ b/src/components/preferences/api-keys/OpenAIModelSelector.tsx
@@ -1,0 +1,78 @@
+import { Check } from 'lucide-react'
+import type { OpenAITranscriptionModel } from '@/bindings'
+import { cn } from '@/lib/utils'
+import { Label } from '../../ui/label'
+import { OPENAI_MODEL_OPTIONS, PRICING_AS_OF_LABEL } from './openaiModels'
+
+interface OpenAIModelSelectorProps {
+  value: OpenAITranscriptionModel
+  onChange: (model: OpenAITranscriptionModel) => void
+  disabled?: boolean
+}
+
+/**
+ * Radio-group selector for the OpenAI file-transcription model.
+ *
+ * Built from native radio inputs so arrow keys, Tab and Space work without
+ * extra key handling.
+ */
+export function OpenAIModelSelector({ value, onChange, disabled }: OpenAIModelSelectorProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <Label id="openai-model-label">Transcription Model</Label>
+        <span className="text-xs text-muted-foreground">Pricing as of {PRICING_AS_OF_LABEL}</span>
+      </div>
+
+      <div role="radiogroup" aria-labelledby="openai-model-label" className="space-y-2">
+        {OPENAI_MODEL_OPTIONS.map((model) => {
+          const isSelected = model.id === value
+
+          return (
+            <label
+              key={model.id}
+              className={cn(
+                'flex items-start gap-3 rounded-lg border p-3 transition-colors',
+                disabled ? 'opacity-60' : 'cursor-pointer hover:bg-accent/50',
+                isSelected && 'border-primary bg-accent/30',
+                'focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2'
+              )}
+            >
+              <input
+                type="radio"
+                name="openai-model"
+                value={model.id}
+                checked={isSelected}
+                disabled={disabled}
+                onChange={() => onChange(model.id)}
+                className="sr-only"
+              />
+
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="flex items-center gap-2 font-medium text-sm">
+                    {model.label}
+                    {isSelected && <Check className="h-4 w-4 text-primary" />}
+                  </span>
+                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                    {model.pricePerMinute}
+                  </span>
+                </div>
+
+                <p className="text-xs text-muted-foreground mt-0.5">{model.description}</p>
+
+                {model.tokenPricing && (
+                  <ul className="mt-1 space-y-0.5 text-xs text-muted-foreground">
+                    {model.tokenPricing.map((line) => (
+                      <li key={line}>{line}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </label>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/preferences/api-keys/OpenAiProvider.tsx
+++ b/src/components/preferences/api-keys/OpenAiProvider.tsx
@@ -6,12 +6,15 @@ import {
 } from '@/hooks/useOpenAIConfig'
 import { waitForPaint } from '@/utils/waitForPaint'
 import { useForm } from '@tanstack/react-form'
+import type { OpenAITranscriptionModel } from '@/bindings'
 import { error as logError } from '@tauri-apps/plugin-log'
 import { Loader2 } from 'lucide-react'
 import { useState } from 'react'
 import { Button } from '../../ui/button'
 import { Input } from '../../ui/input'
 import { Label } from '../../ui/label'
+import { OpenAIModelSelector } from './OpenAIModelSelector'
+import { DEFAULT_OPENAI_MODEL } from './openaiModels'
 import { ProviderSection } from './ProviderSection'
 import type { Provider } from './types'
 import { MASKED_API_KEY_PLACEHOLDER } from './utils'
@@ -37,6 +40,12 @@ export function OpenAIProvider({
   const testConfig = useTestOpenAIConfig()
   const deleteConfig = useDeleteOpenAIConfig()
 
+  // Pending model selection, only set while the user is changing it. Falls back
+  // to the persisted model so the selector always shows what is saved.
+  const [pendingModel, setPendingModel] = useState<OpenAITranscriptionModel | null>(null)
+  const savedModel = existingConfig?.model ?? DEFAULT_OPENAI_MODEL
+  const selectedModel = pendingModel ?? savedModel
+
   const form = useForm({
     defaultValues: {
       apiKey: '',
@@ -48,9 +57,7 @@ export function OpenAIProvider({
         await waitForPaint()
 
         try {
-          const isValid = await testConfig.mutateAsync({
-            apiKey: value.apiKey,
-          })
+          const isValid = await testConfig.mutateAsync({ apiKey: value.apiKey })
 
           if (!isValid) {
             return {
@@ -73,8 +80,9 @@ export function OpenAIProvider({
       setSaveSuccess(false)
 
       try {
-        await saveConfig.mutateAsync({ apiKey: value.apiKey })
+        await saveConfig.mutateAsync({ apiKey: value.apiKey, model: selectedModel })
         setSaveSuccess(true)
+        setPendingModel(null)
         form.reset()
         // Auto-enable the provider after successful save
         if (!isActive) {
@@ -90,6 +98,7 @@ export function OpenAIProvider({
     try {
       await deleteConfig.mutateAsync()
       setSaveSuccess(false)
+      setPendingModel(null)
       form.reset()
       // Deactivate the provider if it was active
       if (isActive) {
@@ -99,6 +108,27 @@ export function OpenAIProvider({
       logError(`[OpenAIProvider] Failed to delete config: ${e}`)
     }
   }
+
+  // With a key already stored, the model can be changed on its own - the
+  // backend keeps the stored key, which is never sent to the frontend.
+  const handleSaveModelOnly = async () => {
+    setSaveSuccess(false)
+
+    try {
+      await saveConfig.mutateAsync({ model: selectedModel })
+      setSaveSuccess(true)
+      setPendingModel(null)
+    } catch (e) {
+      logError(`[OpenAIProvider] Failed to save model: ${e}`)
+    }
+  }
+
+  const handleSelectModel = (model: OpenAITranscriptionModel) => {
+    setPendingModel(model)
+    setSaveSuccess(false)
+  }
+
+  const hasUnsavedModelChange = !!existingConfig && selectedModel !== savedModel
 
   // Derive error message from mutations
   const errorMessage = saveConfig.error?.message || deleteConfig.error?.message
@@ -187,6 +217,17 @@ export function OpenAIProvider({
           </form.Field>
         </div>
 
+        {/* Model selection - saved together with the key, or on its own */}
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <OpenAIModelSelector
+              value={selectedModel}
+              onChange={handleSelectModel}
+              disabled={isSubmitting || saveConfig.isPending}
+            />
+          )}
+        </form.Subscribe>
+
         {/* Feedback messages */}
         <form.Subscribe selector={(state) => state.errorMap}>
           {(errorMap) => (
@@ -203,7 +244,7 @@ export function OpenAIProvider({
           <form.Subscribe
             selector={(state) => [state.canSubmit, state.isSubmitting]}
             children={([canSubmit, isSubmitting]) => (
-              <Button type="submit" disabled={!canSubmit}>
+              <Button type="submit" disabled={!canSubmit || saveConfig.isPending}>
                 {isSubmitting ? (
                   <>
                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -215,6 +256,28 @@ export function OpenAIProvider({
               </Button>
             )}
           />
+
+          {hasUnsavedModelChange && (
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+              {(isSubmitting) => (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleSaveModelOnly}
+                  disabled={isSubmitting || saveConfig.isPending}
+                >
+                  {saveConfig.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : (
+                    'Save Model'
+                  )}
+                </Button>
+              )}
+            </form.Subscribe>
+          )}
         </div>
       </form>
     </ProviderSection>

--- a/src/components/preferences/api-keys/openaiModels.ts
+++ b/src/components/preferences/api-keys/openaiModels.ts
@@ -1,0 +1,66 @@
+import type { OpenAITranscriptionModel } from '@/bindings'
+
+/**
+ * Single source of truth for OpenAI transcription model metadata.
+ *
+ * Pricing is intentionally static — there is no runtime pricing fetch. When
+ * OpenAI changes prices, update the entries below together with
+ * PRICING_AS_OF_LABEL.
+ *
+ * Verified against https://developers.openai.com/api/docs/pricing
+ */
+export const PRICING_AS_OF_LABEL = 'Aug 22, 2026'
+
+export interface OpenAIModelOption {
+  /** API model id, also the persisted value */
+  id: OpenAITranscriptionModel
+  /** Friendly name shown in the selector */
+  label: string
+  /** Headline per-minute audio price */
+  pricePerMinute: string
+  /** Token pricing, shown where per-minute alone is not the whole story */
+  tokenPricing?: string[]
+  /** Short capability note */
+  description: string
+}
+
+export const OPENAI_MODEL_OPTIONS: OpenAIModelOption[] = [
+  {
+    id: 'gpt-transcribe',
+    label: 'GPT Transcribe',
+    pricePerMinute: '~$0.0045/min',
+    description: 'Recommended for recorded speech in its original language.',
+  },
+  {
+    id: 'gpt-4o-mini-transcribe',
+    label: 'GPT-4o Mini Transcribe',
+    pricePerMinute: '~$0.003/min',
+    description: 'Fastest and cheapest option.',
+  },
+  {
+    id: 'gpt-4o-transcribe',
+    label: 'GPT-4o Transcribe',
+    pricePerMinute: '~$0.006/min',
+    description: 'Higher accuracy than the mini model.',
+  },
+  {
+    id: 'gpt-4o-transcribe-diarize',
+    label: 'GPT-4o Transcribe + Diarization',
+    pricePerMinute: '~$0.006/min',
+    tokenPricing: ['$2.50 / 1M audio input tokens', '$10.00 / 1M output tokens'],
+    description: 'Adds speaker labels. Dictara still inserts the plain transcript.',
+  },
+  {
+    id: 'whisper-1',
+    label: 'Whisper',
+    pricePerMinute: '~$0.006/min',
+    description: 'The original Whisper V2 model.',
+  },
+]
+
+/** Model used when no selection has been persisted yet. */
+export const DEFAULT_OPENAI_MODEL: OpenAITranscriptionModel = 'whisper-1'
+
+export function getOpenAIModelOption(id: OpenAITranscriptionModel): OpenAIModelOption {
+  return OPENAI_MODEL_OPTIONS.find((m) => m.id === id) ?? OPENAI_MODEL_OPTIONS[0]
+}

--- a/src/hooks/useOpenAIConfig.ts
+++ b/src/hooks/useOpenAIConfig.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { commands, type OpenAIConfigStatus } from '@/bindings'
+import { commands, type OpenAIConfigStatus, type OpenAITranscriptionModel } from '@/bindings'
 
 export const OPENAI_CONFIG_QUERY_KEY = ['openaiConfig'] as const
 
@@ -21,11 +21,16 @@ export function useOpenAIConfig() {
 }
 
 interface SaveOpenAIConfigParams {
-  apiKey: string
+  /** Omit to keep the already-stored key (model-only update). */
+  apiKey?: string
+  model: OpenAITranscriptionModel
 }
 
 /**
  * Hook to save OpenAI configuration.
+ *
+ * Passing no `apiKey` keeps the key already in the keychain, so the model can
+ * be changed without the user re-entering it.
  * Invalidates the config query on success.
  */
 export function useSaveOpenAIConfig() {
@@ -33,7 +38,7 @@ export function useSaveOpenAIConfig() {
 
   return useMutation({
     mutationFn: async (params: SaveOpenAIConfigParams): Promise<void> => {
-      const result = await commands.saveOpenaiConfig(params.apiKey)
+      const result = await commands.saveOpenaiConfig(params.apiKey ?? null, params.model)
       if (result.status === 'error') {
         throw new Error(result.error)
       }
@@ -50,6 +55,9 @@ interface TestOpenAIConfigParams {
 
 /**
  * Hook to test OpenAI API key validity.
+ *
+ * Validates the credential only - the backend always probes with Whisper, so
+ * the result does not depend on the selected model.
  */
 export function useTestOpenAIConfig() {
   return useMutation({


### PR DESCRIPTION
## Description

Adds selectable OpenAI transcription models to Dictara.

Previously, the OpenAI transcription model was hardcoded to `whisper-1`. This change allows users to select the transcription model from the OpenAI provider settings, with the selected model persisted across app restarts.

The model selector is available in both the Preferences and Onboarding flows through the existing shared OpenAI provider component.

Supported models:

- `gpt-transcribe`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `gpt-4o-transcribe-diarize`
- `whisper-1`

The selector also displays the current pricing information and the date the pricing was last verified.

Existing configurations without a saved model remain compatible and fall back to `whisper-1`.

Realtime transcription models are intentionally not included in this change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have run `npm run verify` and all checks pass
- [x] I have tested my changes locally
- [x] I have added/updated tests if applicable
- [x] I have updated documentation if needed
- [x] My code follows the project's code style

## Screenshots

<img width="495" height="640" alt="Screenshot 2026-09-01 - 10 14 04" src="https://github.com/user-attachments/assets/7d768ac7-c45f-41c8-9374-ea7bd14ba69e" />

## Related Issues

<!-- No related issue -->
